### PR TITLE
Reduce Upper Limit on AllenNLP Dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-allennlp>=2.3.0,<2.10
+allennlp>=2.3.0,<=2.9.0.dev20211215
 datasets>=1.13.0,<2.0
 deepdiff>=5.2.0
 jury>=2.1.0,<3.0


### PR DESCRIPTION
Currently normal releases of AllenNLP at 2.9.X cause errors due to a type hint bug in Transformers, this is mostly a band-aid until that hint gets fixed.