### PR TITLE
Update Transformers and AllenNLP Requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-allennlp==2.10.0
+allennlp>=2.10.0,<2.11
 datasets>=1.13.0,<2.0
 deepdiff>=5.2.0
 jury>=2.1.0,<3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-allennlp>=2.3.0,<=2.9.0.dev20211215
+allennlp==2.10.0
 datasets>=1.13.0,<2.0
 deepdiff>=5.2.0
 jury>=2.1.0,<3.0
 numpy>=1.21.2
 seqeval==1.2.2
 tensorboardX==2.1
-transformers>=4.11.0,<4.16
+transformers>=4.19,<4.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ jury>=2.1.0,<3.0
 numpy>=1.21.2
 seqeval==1.2.2
 tensorboardX==2.1
-transformers>=4.19,<4.21
+transformers>=4.18,<4.21

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def get_requirements():
 
 extras_require = {
     "dev": [
-        "black==21.7b0",
+        "black==22.3.0",
         "flake8==3.9.2",
         "isort==5.9.2",
         "pytest>=6.2.4",


### PR DESCRIPTION
With Transformers 4.18, we can use the new versions of transformers. There was a range of versions before that had a typing error which caused errors.

The earliest version of AllenNLP that supports 4.18 is 2.9.3. Which then had a bug with cached-path being updated and breaking some of the things on their side. 2.10.0, therefore, is the earliest version we can support with the new transformer requirement (and currently is the latest version).