### PR TITLE
Adding support for distributed training

### DIFF
--- a/trapper/commands.py
+++ b/trapper/commands.py
@@ -161,9 +161,10 @@ def run_distributed(args=None):
 
     def merge_json_str(opts: List[str]) -> None:
         """
-        Merges the JSON structures from given command line arguments.
-        Implements a try/except block to merge json. Note that it modifies
-        given args list inplace.
+        Merges the JSON structures from given command line arguments to correct
+        the JSON structure passed by `--overrides` argument. Implements a
+        try/except block to merge json. Note that it modifies given args
+        list inplace.
 
         Notes:
             The argparser may divide the given json structure to multiple

--- a/trapper/commands.py
+++ b/trapper/commands.py
@@ -18,21 +18,21 @@ from the AllenNLP library at https://github.com/allenai/allennlp.
 
 import argparse
 import sys
+import uuid
 from abc import ABCMeta
 from typing import Dict, Optional, Set, Tuple, Type
-import uuid
 
 import allennlp as _allennlp
 from allennlp.commands import ArgumentParserWithDefaults
 from allennlp.common.util import import_module_and_submodules
 from jury.utils.common import replace as list_replace
+from torch.distributed.elastic.multiprocessing.errors import record
 from torch.distributed.elastic.utils.logging import get_logger
 from torch.distributed.launcher.api import elastic_launch
-from torch.distributed.run import get_args_parser as torch_distributed_args_parser
 from torch.distributed.run import config_from_args as torch_config_from_args
-from torch.distributed.elastic.multiprocessing.errors import record
+from torch.distributed.run import get_args_parser as torch_distributed_args_parser
 
-from trapper import __version__, PROJECT_ROOT
+from trapper import PROJECT_ROOT, __version__
 from trapper.common.plugins import import_plugins
 from trapper.common.utils import append_parent_docstr, merge_args_safe
 from trapper.training.train import run_experiment
@@ -163,7 +163,7 @@ def run_distributed(args):
     training_script_idx = cmd_args.index("distributed-run")
     trapper_main_script = str(PROJECT_ROOT / "trapper/__main__.py")
     list_replace(cmd_args, trapper_main_script, training_script_idx)
-    cmd_args.insert(training_script_idx+1, "run")
+    cmd_args.insert(training_script_idx + 1, "run")
 
     elastic_launch(
         config=config,

--- a/trapper/commands.py
+++ b/trapper/commands.py
@@ -17,10 +17,11 @@ from the AllenNLP library at https://github.com/allenai/allennlp.
 """
 
 import argparse
+import json
 import sys
 import uuid
 from abc import ABCMeta
-from typing import Dict, Optional, Set, Tuple, Type
+from typing import Dict, List, Optional, Set, Tuple, Type
 
 import allennlp as _allennlp
 from allennlp.commands import ArgumentParserWithDefaults
@@ -34,7 +35,7 @@ from torch.distributed.run import get_args_parser as torch_distributed_args_pars
 
 from trapper import PROJECT_ROOT, __version__
 from trapper.common.plugins import import_plugins
-from trapper.common.utils import append_parent_docstr, merge_args_safe
+from trapper.common.utils import append_parent_docstr
 from trapper.training.train import run_experiment
 
 
@@ -103,21 +104,22 @@ class Run(Subcommand):
         return subparser
 
 
-@Subcommand.register("distributed-run")
+@Subcommand.register("run-distributed")
 class DistributedRun(Subcommand):
-    """trapper's run command that enables running an experiment in
-    a distributed way.
+    """Start an experiment in a distributed data parallel fashion using the config file.
+    It utilizes pytorch's elastic run under the hood. To see supported features see
+    https://pytorch.org/docs/stable/elastic/run.html
 
     Usage:
         Basic:
-            ` trapper distributed-run experiment.jsonnet <--other-kwargs vals>`
+            ` trapper run-distributed experiment.jsonnet <--other-kwargs vals>`
     """
 
     def add_subparser(
         self, parser: argparse._SubParsersAction
     ) -> argparse.ArgumentParser:
-        description = """Distributed run the experiment specified in the config file which
-         specify the training and/or evaluation of a model on a dataset."""
+        description = """Run the experiment specified in the config file in a 
+            distributed fashion across multiple devices (DDP)."""
         subparser = parser.add_parser(
             self.name,
             description=description,
@@ -131,16 +133,66 @@ class DistributedRun(Subcommand):
             " format describing the model, dataset and other details.",
         )
 
-        subparser.set_defaults(func=torch_distributed_run)
+        subparser.add_argument(
+            "-o",
+            "--overrides",
+            type=str,
+            default="",
+            help=(
+                "a json or jsonnet structure used to override the experiment "
+                "configuration, e.g., '{\"optimizer.lr\": 1e-5}'.  Nested "
+                "parameters can be specified either with nested dictionaries "
+                "or with dot syntax."
+            ),
+        )
+
+        subparser.set_defaults(func=run_distributed)
 
         return subparser
 
 
-def run_distributed(args):
+@record
+def run_distributed(args=None):
     """
-    Taken from https://github.com/pytorch/pytorch/blob/master/torch/distributed/run.py
+    Taken from
+    https://github.com/pytorch/pytorch/blob/4618371da56c887195e2e1d16dad2b9686302800/torch/distributed/run.py
     and modified to properly run by trapper.
     """
+
+    def merge_json_str(opts: List[str]) -> None:
+        """
+        Merges the JSON structures from given command line arguments.
+        Implements a simple stack to merge json. Note that it modifies
+        given args list inplace.
+
+        Args:
+            *opts:
+
+        Returns:
+            List of strings json where JSON structures merged.
+        """
+        start = step = 1
+
+        i = 0
+        while i < len(opts):
+            if opts[i].count("{") >= 1:
+                start = i
+                break
+            i += 1
+
+        while start + step < len(opts) + 1:
+            end = start + step
+            try:
+                json_shards = " ".join(opts[start:end])
+                json.loads(json_shards)
+            except json.decoder.JSONDecodeError:
+                step += 1
+            else:
+                json_str = " ".join(opts[start:end])
+                del opts[start:end]
+                opts.insert(start, json_str)
+                break
+
     if args.standalone:
         args.rdzv_backend = "c10d"
         args.rdzv_endpoint = "localhost:29400"
@@ -160,7 +212,8 @@ def run_distributed(args):
     # config parser. Effectively, running the following cmd
     # $ torchrun TORCHRUN_OPTS /path/to/trapper/__main__.py run TRAPPER_OPTS
     #
-    training_script_idx = cmd_args.index("distributed-run")
+    merge_json_str(cmd_args)
+    training_script_idx = cmd_args.index("run-distributed")
     trapper_main_script = str(PROJECT_ROOT / "trapper/__main__.py")
     list_replace(cmd_args, trapper_main_script, training_script_idx)
     cmd_args.insert(training_script_idx + 1, "run")
@@ -175,16 +228,14 @@ def torch_distributed_parse_args():
     torch_parser = torch_distributed_args_parser()
     dist_args, _ = torch_parser.parse_known_args()
     for flag in dist_args.training_script_args[1:]:
-        opt, f, v = torch_parser._parse_optional(flag)
-        if opt is not None:
-            setattr(dist_args, opt.dest, v)
-            dist_args.training_script_args.remove(flag)
+        if "=" in flag:
+            # torch parser can only parse args if '=' is used between key and value
+            # we do not perform any polishing merge of keys and values
+            opt, f, v = torch_parser._parse_optional(flag)
+            if opt is not None:
+                setattr(dist_args, opt.dest, v)
+                dist_args.training_script_args.remove(flag)
     return dist_args
-
-
-@record
-def torch_distributed_run(args=None):
-    run_distributed(args)
 
 
 def run_experiment_from_args(args: argparse.Namespace):
@@ -194,6 +245,23 @@ def run_experiment_from_args(args: argparse.Namespace):
     run_experiment(args.config_path, args.overrides)
 
 
+def merge_args_safe(
+    args1: argparse.Namespace, args2: argparse.Namespace
+) -> argparse.Namespace:
+    """
+    Merges two namespaces but throws an error if there are keys that collide.
+
+    ref: https://stackoverflow.com/questions/56136549/how-can-i-merge-two-argparse-namespaces-in-python-2-x
+    :param args1:
+    :param args2:
+    :return:
+    """
+    # - the merged args
+    # The vars() function returns the __dict__ attribute to values of the given object e.g {field:value}.
+    merged_args = argparse.Namespace(**vars(args1), **vars(args2))
+    return merged_args
+
+
 def parse_args(
     prog: Optional[str] = None,
 ) -> Tuple[argparse.ArgumentParser, argparse.Namespace]:
@@ -201,6 +269,7 @@ def parse_args(
     Creates the argument parser for the main program and uses it to parse the args.
     (Note: This function is adapted from `allennlp.commands.__init__.parse_args`).
     """
+
     parser = ArgumentParserWithDefaults(description="Run Trapper", prog=prog)
     parser.add_argument(
         "--version", action="version", version=f"%(prog)s {__version__}"
@@ -241,12 +310,10 @@ def parse_args(
         add_subcommands()
 
     # Now we can parse the arguments.
-    if argv[0] == "distributed-run":
-        dist_args = torch_distributed_parse_args()
-    else:
-        dist_args = argparse.Namespace()
     args, _ = parser.parse_known_args()
-    args = merge_args_safe(args, dist_args)
+    if argv[0] == "run-distributed":
+        dist_args = torch_distributed_parse_args()
+        args = merge_args_safe(args, dist_args)
 
     if (
         not plugins_imported and Subcommand.by_name(argv[0]).requires_plugins

--- a/trapper/commands.py
+++ b/trapper/commands.py
@@ -20,10 +20,17 @@ import argparse
 import sys
 from abc import ABCMeta
 from typing import Dict, Optional, Set, Tuple, Type
+import uuid
 
 import allennlp as _allennlp
 from allennlp.commands import ArgumentParserWithDefaults
 from allennlp.common.util import import_module_and_submodules
+from jury.utils.common import replace as list_replace
+from torch.distributed.elastic.utils.logging import get_logger
+from torch.distributed.launcher.api import elastic_launch
+from torch.distributed.run import get_args_parser as torch_distributed_args_parser
+from torch.distributed.run import config_from_args as torch_config_from_args
+from torch.distributed.elastic.multiprocessing.errors import record
 
 from trapper import __version__
 from trapper.common.plugins import import_plugins
@@ -43,6 +50,8 @@ class Subcommand(_allennlp.commands.Subcommand, metaclass=ABCMeta):
 
 # Getting rid of unused commands in allennlp
 _allennlp.commands.Subcommand = Subcommand
+
+log = get_logger()
 
 
 @Subcommand.register("run")
@@ -92,6 +101,76 @@ class Run(Subcommand):
         subparser.set_defaults(func=run_experiment_from_args)
 
         return subparser
+
+
+@Subcommand.register("distributed-run")
+class DistributedRun(Subcommand):
+    """trapper's main command that enables creating and running an experiment
+    form a config file.
+
+    Usage:
+        Basic:
+            ` trapper distributed-run --config_path experiment.jsonnet `
+
+        With overrides flag:
+           ` trapper distributed-run --config_path experiment.jsonnet `
+    """
+
+    def add_subparser(
+        self, parser: argparse._SubParsersAction
+    ) -> argparse.ArgumentParser:
+        description = """Distributed run the experiment specified in the config file which
+         specify the training and/or evaluation of a model on a dataset."""
+        subparser = parser.add_parser(
+            self.name,
+            description=description,
+            help="Start distributed training of a model.",
+        )
+
+        subparser.add_argument(
+            "config_path",
+            type=str,
+            help="path to the experiment config file in `json` or `jsonnet`"
+            " format describing the model, dataset and other details.",
+        )
+
+        subparser.set_defaults(func=torch_distributed_run)
+
+        return subparser
+
+
+def run_distributed(args):
+    if args.standalone:
+        args.rdzv_backend = "c10d"
+        args.rdzv_endpoint = "localhost:29400"
+        args.rdzv_id = str(uuid.uuid4())
+        log.info(
+            f"\n**************************************\n"
+            f"Rendezvous info:\n"
+            f"--rdzv_backend={args.rdzv_backend} "
+            f"--rdzv_endpoint={args.rdzv_endpoint} "
+            f"--rdzv_id={args.rdzv_id}\n"
+            f"**************************************\n"
+        )
+
+    config, cmd, cmd_args = torch_config_from_args(args)
+    training_script_idx = cmd_args.index("distributed-run")
+    from trapper import PROJECT_ROOT
+
+    trapper_main_script = str(PROJECT_ROOT / "trapper/__main__.py")
+
+    list_replace(cmd_args, trapper_main_script, training_script_idx)
+    cmd_args.insert(training_script_idx+1, "run")
+
+    elastic_launch(
+        config=config,
+        entrypoint=cmd,
+    )(*cmd_args)
+
+
+@record
+def torch_distributed_run(args=None):
+    run_distributed(args)
 
 
 def run_experiment_from_args(args: argparse.Namespace):
@@ -149,6 +228,10 @@ def parse_args(
 
     # Now we can parse the arguments.
     args = parser.parse_args()
+    if argv[0] == "distributed-run":
+        torch_parser = torch_distributed_args_parser()
+        dist_args = torch_parser.parse_args()
+        args = merge_args_safe(args, dist_args)
 
     if (
         not plugins_imported and Subcommand.by_name(argv[0]).requires_plugins

--- a/trapper/commands.py
+++ b/trapper/commands.py
@@ -162,11 +162,18 @@ def run_distributed(args=None):
     def merge_json_str(opts: List[str]) -> None:
         """
         Merges the JSON structures from given command line arguments.
-        Implements a simple stack to merge json. Note that it modifies
+        Implements a try/except block to merge json. Note that it modifies
         given args list inplace.
 
+        Notes:
+            The argparser may divide the given json structure to multiple
+            shards if it has whitespace between key and value (e.g.
+            {\"key\": \"abc\"} -argparse-> ['{\"key\":', '\"abc\"}']). This
+            function takes the sharded arguments and merges them if they
+            construct a valid JSON structure.
+
         Args:
-            *opts:
+            opts:
 
         Returns:
             List of strings json where JSON structures merged.

--- a/trapper/commands.py
+++ b/trapper/commands.py
@@ -34,7 +34,7 @@ from torch.distributed.elastic.multiprocessing.errors import record
 
 from trapper import __version__
 from trapper.common.plugins import import_plugins
-from trapper.common.utils import append_parent_docstr
+from trapper.common.utils import append_parent_docstr, merge_args_safe
 from trapper.training.train import run_experiment
 
 

--- a/trapper/commands.py
+++ b/trapper/commands.py
@@ -170,6 +170,8 @@ def run_distributed(args):
 
 @record
 def torch_distributed_run(args=None):
+    # Example:
+    # trapper distributed-run trapper/examples/question_answering/experiment.jsonnet
     run_distributed(args)
 
 

--- a/trapper/common/utils.py
+++ b/trapper/common/utils.py
@@ -1,7 +1,7 @@
 """
 Various utilities for working on data, docstrings etc while using trapper.
 """
-
+import argparse
 from typing import Callable, Dict, List, Type, Union
 
 from deepdiff import DeepDiff
@@ -82,3 +82,18 @@ def add_property(inst, name_to_method: Dict[str, Callable]):
 def is_equal(x: Union[Dict, List], y: Union[Dict, List]) -> bool:
     """Checks equality of two nested container type e.g. list or dict"""
     return not DeepDiff(x, y)
+
+
+def merge_args_safe(args1: argparse.Namespace, args2: argparse.Namespace) -> argparse.Namespace:
+    """
+    Merges two namespaces but throws an error if there are keys that collide.
+
+    ref: https://stackoverflow.com/questions/56136549/how-can-i-merge-two-argparse-namespaces-in-python-2-x
+    :param args1:
+    :param args2:
+    :return:
+    """
+    # - the merged args
+    # The vars() function returns the __dict__ attribute to values of the given object e.g {field:value}.
+    args = argparse.Namespace(**vars(args1), **vars(args2))
+    return args

--- a/trapper/common/utils.py
+++ b/trapper/common/utils.py
@@ -84,7 +84,9 @@ def is_equal(x: Union[Dict, List], y: Union[Dict, List]) -> bool:
     return not DeepDiff(x, y)
 
 
-def merge_args_safe(args1: argparse.Namespace, args2: argparse.Namespace) -> argparse.Namespace:
+def merge_args_safe(
+    args1: argparse.Namespace, args2: argparse.Namespace
+) -> argparse.Namespace:
     """
     Merges two namespaces but throws an error if there are keys that collide.
 

--- a/trapper/common/utils.py
+++ b/trapper/common/utils.py
@@ -1,7 +1,6 @@
 """
 Various utilities for working on data, docstrings etc while using trapper.
 """
-import argparse
 from typing import Callable, Dict, List, Type, Union
 
 from deepdiff import DeepDiff
@@ -82,20 +81,3 @@ def add_property(inst, name_to_method: Dict[str, Callable]):
 def is_equal(x: Union[Dict, List], y: Union[Dict, List]) -> bool:
     """Checks equality of two nested container type e.g. list or dict"""
     return not DeepDiff(x, y)
-
-
-def merge_args_safe(
-    args1: argparse.Namespace, args2: argparse.Namespace
-) -> argparse.Namespace:
-    """
-    Merges two namespaces but throws an error if there are keys that collide.
-
-    ref: https://stackoverflow.com/questions/56136549/how-can-i-merge-two-argparse-namespaces-in-python-2-x
-    :param args1:
-    :param args2:
-    :return:
-    """
-    # - the merged args
-    # The vars() function returns the __dict__ attribute to values of the given object e.g {field:value}.
-    args = argparse.Namespace(**vars(args1), **vars(args2))
-    return args

--- a/trapper/training/train.py
+++ b/trapper/training/train.py
@@ -37,9 +37,7 @@ def run_experiment(
     Returns:
         Experiment's results e.g. the metric values in a dict
     """
-    params = _read_experiment_params(
-        str(config_path), params_overrides, ext_vars
-    )
+    params = _read_experiment_params(str(config_path), params_overrides, ext_vars)
     return _run_experiment_from_params(params)
 
 

--- a/trapper/training/train.py
+++ b/trapper/training/train.py
@@ -37,8 +37,11 @@ def run_experiment(
     Returns:
         Experiment's results e.g. the metric values in a dict
     """
-    params = _read_experiment_params(str(config_path), params_overrides, ext_vars)
-    return _run_experiment_from_params(params)
+    local_rank = os.getenv("LOCAL_RANK")
+    if local_rank is None or local_rank == 0:
+        params = _read_experiment_params(str(config_path), params_overrides, ext_vars)
+        return _run_experiment_from_params(params)
+    print("Not main process!")
 
 
 def _read_experiment_params(
@@ -59,8 +62,10 @@ def _read_experiment_params(
 
 
 def _run_experiment_from_params(params: Params) -> Dict[str, float]:
-    serialization_dirs = _create_serialization_dirs(params)
-    _save_experiment_config(params, serialization_dirs)
+    local_rank = os.getenv("LOCAL_RANK")
+    if local_rank is None or local_rank == 0:
+        serialization_dirs = _create_serialization_dirs(params)
+        _save_experiment_config(params, serialization_dirs)
     trainer = TransformerTrainer.from_params(params)
     return run_experiment_using_trainer(trainer)
 

--- a/trapper/training/train.py
+++ b/trapper/training/train.py
@@ -59,8 +59,8 @@ def _read_experiment_params(
 
 
 def _run_experiment_from_params(params: Params) -> Dict[str, float]:
-    local_rank = os.getenv("LOCAL_RANK")
-    if local_rank is None or local_rank == 0:
+    local_rank = os.getenv("LOCAL_RANK", -1)
+    if is_main_process(local_rank):
         serialization_dirs = _create_serialization_dirs(params)
         _save_experiment_config(params, serialization_dirs)
     trainer = TransformerTrainer.from_params(params)

--- a/trapper/training/train.py
+++ b/trapper/training/train.py
@@ -39,7 +39,9 @@ def run_experiment(
     """
     local_rank = os.getenv("LOCAL_RANK")
     if local_rank is None or local_rank == 0:
-        params = _read_experiment_params(str(config_path), params_overrides, ext_vars)
+        params = _read_experiment_params(
+            str(config_path), params_overrides, ext_vars
+        )
         return _run_experiment_from_params(params)
     print("Not main process!")
 

--- a/trapper/training/train.py
+++ b/trapper/training/train.py
@@ -37,13 +37,10 @@ def run_experiment(
     Returns:
         Experiment's results e.g. the metric values in a dict
     """
-    local_rank = os.getenv("LOCAL_RANK")
-    if local_rank is None or local_rank == 0:
-        params = _read_experiment_params(
-            str(config_path), params_overrides, ext_vars
-        )
-        return _run_experiment_from_params(params)
-    print("Not main process!")
+    params = _read_experiment_params(
+        str(config_path), params_overrides, ext_vars
+    )
+    return _run_experiment_from_params(params)
 
 
 def _read_experiment_params(


### PR DESCRIPTION
This PR adds parallelism to training phase by utilizing `torch.distributed` backend. `torchrun` is monkey-patched to properly run distributed training by trapper CLI.