### PR TITLE
Add output handler to trainer args

### DIFF
--- a/examples/pos_tagging/tests/conftest.py
+++ b/examples/pos_tagging/tests/conftest.py
@@ -52,6 +52,7 @@ def experiment_params(
         "model_wrapper": {"type": "token_classification", "num_labels": 47},
         "compute_metrics": {"metric_params": "seqeval"},
         "metric_input_handler": {"type": "token-classification"},
+        "metric_output_handler": {"type": "default"},
         "label_mapper": {"type": "conll2003_pos_tagging_example"},
         "args": {
             "type": "default",

--- a/test_fixtures/commands/experiment_trivial.jsonnet
+++ b/test_fixtures/commands/experiment_trivial.jsonnet
@@ -27,6 +27,7 @@
     "metric_input_handler": {
         "type": "question-answering"
     },
+    "metric_output_handler": {"type": "default"},
     "compute_metrics": {
         "metric_params": [
             "squad"

--- a/test_fixtures/pipelines/pipeline_integration_experiment.jsonnet
+++ b/test_fixtures/pipelines/pipeline_integration_experiment.jsonnet
@@ -29,6 +29,7 @@ local result_dir = std.extVar("OUTPUT_PATH");
     "metric_input_handler": {
         "type": "question-answering"
     },
+    "metric_output_handler": {"type": "default"},
     "compute_metrics": {
         "metric_params": [
             "squad"

--- a/tests/training/test_basic_trainer_for_question_answering.py
+++ b/tests/training/test_basic_trainer_for_question_answering.py
@@ -31,6 +31,7 @@ def trainer_params(
         "model_wrapper": {"type": "question_answering"},
         "compute_metrics": {"metric_params": ["squad"]},
         "metric_input_handler": {"type": "question-answering"},
+        "metric_output_handler": {"type": "default"},
         "args": {
             "type": "default",
             "output_dir": temp_output_dir + "/checkpoints",

--- a/tests/training/test_seq2seq_trainer.py
+++ b/tests/training/test_seq2seq_trainer.py
@@ -128,6 +128,7 @@ def trainer_params(
         "model_wrapper": {"type": "seq2seq_lm"},
         "compute_metrics": {"metric_params": ["rouge"]},
         "metric_input_handler": {"type": "language-generation"},
+        "metric_output_handler": {"type": "default"},
         "args": {
             "type": "seq2seq",
             "output_dir": temp_output_dir + "/checkpoints",

--- a/trapper/training/trainer.py
+++ b/trapper/training/trainer.py
@@ -151,11 +151,13 @@ class TransformerTrainer(_Trainer, Registrable):
         cls,
         compute_metrics: Optional[Lazy[Metric]],
         input_handler: MetricInputHandler,
-        output_handler: MetricOutputHandler
+        output_handler: MetricOutputHandler,
     ) -> Optional[Metric]:
         if compute_metrics is None:
             return None
-        return compute_metrics.construct(input_handler=input_handler, output_handler=output_handler)
+        return compute_metrics.construct(
+            input_handler=input_handler, output_handler=output_handler
+        )
 
     @classmethod
     def mark_params_with_no_grads(

--- a/trapper/training/trainer.py
+++ b/trapper/training/trainer.py
@@ -12,6 +12,7 @@ from trapper.common.plugins import import_plugins
 from trapper.common.utils import append_parent_docstr
 from trapper.data import DatasetLoader, LabelMapper, TokenizerWrapper
 from trapper.data.data_collator import DataCollator
+from trapper.metrics import MetricOutputHandler
 from trapper.metrics.input_handlers.input_handler import MetricInputHandler
 from trapper.metrics.metric import Metric
 from trapper.models import ModelWrapper
@@ -67,6 +68,7 @@ class TransformerTrainer(_Trainer, Registrable):
         data_collator: Lazy[DataCollator],
         optimizer: Lazy[Optimizer],
         metric_input_handler: Lazy[MetricInputHandler],
+        metric_output_handler: Lazy[MetricOutputHandler],
         label_mapper: Optional[LabelMapper] = None,
         compute_metrics: Optional[Lazy[Metric]] = None,
         no_grad: List[str] = None,
@@ -112,8 +114,10 @@ class TransformerTrainer(_Trainer, Registrable):
         )
         metric_input_handler_.extract_metadata(eval_dataset_)
 
+        metric_output_handler_ = metric_output_handler.construct()
+
         compute_metrics_ = cls._create_compute_metrics(
-            compute_metrics, metric_input_handler_
+            compute_metrics, metric_input_handler_, metric_output_handler_
         )
 
         return cls(
@@ -147,10 +151,11 @@ class TransformerTrainer(_Trainer, Registrable):
         cls,
         compute_metrics: Optional[Lazy[Metric]],
         input_handler: MetricInputHandler,
+        output_handler: MetricOutputHandler
     ) -> Optional[Metric]:
         if compute_metrics is None:
             return None
-        return compute_metrics.construct(input_handler=input_handler)
+        return compute_metrics.construct(input_handler=input_handler, output_handler=output_handler)
 
     @classmethod
     def mark_params_with_no_grads(


### PR DESCRIPTION
Output handler class exists; however, it could not be used in trainer. This PR adds `metric_output_handler` to the Trainer.